### PR TITLE
Add __str__() method to TheoreticalSemivariogram class

### DIFF
--- a/pyinterpolate/semivariance/semivariogram_fit/fit_semivariance.py
+++ b/pyinterpolate/semivariance/semivariogram_fit/fit_semivariance.py
@@ -60,6 +60,9 @@ class TheoreticalSemivariogram:
         self.sill = None
         self.model_error = None
         self.is_weighted = False
+        
+    def __str__(self):
+        return "chosen_model_name: {chosen_model_name}\nnugget: {nugget}\nrange: {range}\nsill: {sill}\nmodel_error: {model_error}\nis_weighted: {is_weighted}".format(**self.__dict__)
 
     # MODELS
 


### PR DESCRIPTION
## Package version (main branch)
version: **0.2.3.post1**

## Description
The __str__() method is now implemented to allow information about a TheoreticalSemivariogram object to be easily shown.

## Problem
Users can call print() on the object to quickly see the current values.

## Solution
Displays following variable names and the current value:
* self.chosen_model_name
* self.nugget
* self.range
* self.sill
* self.model_error
* self.is_weighted

### Affected modules

- TheoreticalSemivariogram class (pyinterpolate/semivariance/semivariogram_fit/fit_semivariance.py)


### Package check

- [x] All tests passed
- [x] Documentation updated
- [x] All tutorials are working properly


