### PR TITLE
V0.3 empirical variogram class

### DIFF
--- a/pyinterpolate/test/test_variogram/empirical/test_covariance.py
+++ b/pyinterpolate/test/test_variogram/empirical/test_covariance.py
@@ -35,12 +35,11 @@ REFERENCE_INPUT_ZEROS = np.array([
 # EXPECTED OUTPUTS
 
 EXPECTED_OUTPUT_OMNI = np.array([
-    [0, 4.248, 0, 0],
-    [1, -0.543, 24, 30.71],
-    [2, -0.795, 22, 30.25],
-    [3, -1.26, 20, 31.36],
-    [4, -0.197, 18, 30.864],
-    [5, 1.234, 16, 28.891]
+    [1, -0.543, 24],
+    [2, -0.795, 22],
+    [3, -1.26, 20],
+    [4, -0.197, 18],
+    [5, 1.234, 16]
 ])
 
 EXPECTED_VARIANCE_CO_OUTPUT = 4.248
@@ -55,7 +54,6 @@ EXPECTED_OUTPUT_ARMSTRONG_LAG1 = 6.649
 # CONSTS
 STEP_SIZE = 1
 MAX_RANGE = 6
-RETURN_MEAN_SQUARED = True
 
 
 class TestCovariance(unittest.TestCase):
@@ -63,23 +61,22 @@ class TestCovariance(unittest.TestCase):
     # OMNIDIRECTIONAL CASES
 
     def test_variance_c0(self):
-        output = calculate_covariance(REFERENCE_INPUT_WE, step_size=STEP_SIZE, max_range=MAX_RANGE,
-                                      return_lag_squared_means=RETURN_MEAN_SQUARED)
-        c0 = output[0][1]
+        output = calculate_covariance(REFERENCE_INPUT_WE, step_size=STEP_SIZE, max_range=MAX_RANGE)
+        c0 = output[1]
         msg = f'Expected variance of the input dataset is {EXPECTED_VARIANCE_CO_OUTPUT} but ' \
               f'{c0} was returned.'
         self.assertAlmostEqual(c0, EXPECTED_VARIANCE_CO_OUTPUT, 2, msg=msg)
 
     def test_calculate_covariance_single_row(self):
-        output = calculate_covariance(REFERENCE_INPUT_WE, step_size=STEP_SIZE, max_range=MAX_RANGE,
-                                      return_lag_squared_means=RETURN_MEAN_SQUARED)
+        output = calculate_covariance(REFERENCE_INPUT_WE, step_size=STEP_SIZE, max_range=MAX_RANGE)
+        output = output[0]
         are_close = np.allclose(output, EXPECTED_OUTPUT_OMNI, rtol=1.e-2)
         msg = 'The difference between expected values and calculated covariances are too large, check calculations.'
         self.assertTrue(are_close, msg)
 
     def test_calculate_covariance_zeros_omni(self):
         output = calculate_covariance(REFERENCE_INPUT_ZEROS, step_size=STEP_SIZE, max_range=MAX_RANGE)
-        mean_val = np.mean(output[:, 1])
+        mean_val = np.mean(output[0][:, 1])
         msg = 'Calculated covariance should be equal to zero if we provide only zeros array.'
         self.assertEqual(mean_val, EXPECTED_OUTPUT_ZEROS, msg)
 
@@ -90,7 +87,7 @@ class TestCovariance(unittest.TestCase):
         path_to_the_data = os.path.join(my_dir, filepath)
         arr = np.load(path_to_the_data)
         cov = calculate_covariance(arr, 1, 2, get_c0=False)
-        lag1_test_value = cov[0][1]
+        lag1_test_value = cov[0][0][1]
         err_msg = f'Calculated covariance for lag 1 should be equal to {EXPECTED_OUTPUT_ARMSTRONG_LAG1} for ' \
                   f'omnidirectional case and points within {filename} file.'
         self.assertAlmostEqual(lag1_test_value, EXPECTED_OUTPUT_ARMSTRONG_LAG1, places=2, msg=err_msg)
@@ -104,7 +101,7 @@ class TestCovariance(unittest.TestCase):
         path_to_the_data = os.path.join(my_dir, filepath)
         arr = np.load(path_to_the_data)
         cov = calculate_covariance(arr, 1, 2, direction=0, tolerance=0.01, get_c0=False)
-        lag1_test_value = cov[0][1]
+        lag1_test_value = cov[0][0][1]
         err_msg = f'Calculated covariance for lag 1 should be equal to {EXPECTED_OUTPUT_ARMSTRONG_NS_LAG1} for ' \
                   f'N-S direction case and points within {filename} file.'
         self.assertAlmostEqual(lag1_test_value, EXPECTED_OUTPUT_ARMSTRONG_NS_LAG1, places=2, msg=err_msg)
@@ -116,6 +113,7 @@ class TestCovariance(unittest.TestCase):
         path_to_the_data = os.path.join(my_dir, filepath)
         arr = np.load(path_to_the_data)
         cov = calculate_covariance(arr, 1, 2, direction=90, tolerance=0.1, get_c0=False)
+        cov = cov[0]
         lag1_test_value = cov[0][1]
         err_msg = f'Calculated semivariance for lag 1 should be equal to {EXPECTED_OUTPUT_ARMSTRONG_WE_LAG1} for ' \
                   f'W-E direction case and points within {filename} file.'
@@ -128,6 +126,7 @@ class TestCovariance(unittest.TestCase):
         path_to_the_data = os.path.join(my_dir, filepath)
         arr = np.load(path_to_the_data)
         cov = calculate_covariance(arr, 1, 4, direction=135, tolerance=0.01, get_c0=False)
+        cov = cov[0]
         lag1_test_value = cov[1][1]
         err_msg = f'Calculated covariance for lag 1 should be equal to {EXPECTED_OUTPUT_ARMSTRONG_NW_SE_LAG2} for ' \
                   f'NW-SE direction case and points within {filename} file.'
@@ -140,6 +139,7 @@ class TestCovariance(unittest.TestCase):
         path_to_the_data = os.path.join(my_dir, filepath)
         arr = np.load(path_to_the_data)
         cov = calculate_covariance(arr, 1, 3, direction=45, tolerance=0.01, get_c0=False)
+        cov = cov[0]
         lag1_test_value = cov[1][1]
         err_msg = f'Calculated coivariance for lag 1 should be equal to {EXPECTED_OUTPUT_ARMSTRONG_NE_SW_LAG2} for ' \
                   f'NE-SW direction case and points within {filename} file.'

--- a/pyinterpolate/test/test_variogram/empirical/test_empirical_semivariance_class.py
+++ b/pyinterpolate/test/test_variogram/empirical/test_empirical_semivariance_class.py
@@ -1,0 +1,273 @@
+# Core modules
+import unittest
+# Math modules
+import numpy as np
+# Package modules
+from pyinterpolate.variogram.empirical.covariance import calculate_covariance
+from pyinterpolate.variogram.empirical.semivariance import calculate_semivariance
+# Tested module
+from pyinterpolate.variogram.empirical.empirical_semivariogram import build_experimental_variogram, \
+    EmpiricalSemivariogram
+
+# REFERENCE INPUTS
+REFERENCE_INPUT_WE = np.array([
+    [0, 0, 8],
+    [1, 0, 6],
+    [2, 0, 4],
+    [3, 0, 3],
+    [4, 0, 6],
+    [5, 0, 5],
+    [6, 0, 7],
+    [7, 0, 2],
+    [8, 0, 8],
+    [9, 0, 9],
+    [10, 0, 5],
+    [11, 0, 6],
+    [12, 0, 3]
+])
+REFERENCE_INPUT_ZEROS = np.array([
+    [0, 0, 0],
+    [0, 1, 0],
+    [1, 0, 0],
+    [1, 1, 0],
+    [2, 1, 0],
+    [1, 2, 0],
+    [2, 2, 0],
+    [3, 3, 0],
+    [3, 1, 0],
+    [3, 2, 0]
+])
+REFERENCE_INPUT_BOUNDED = np.array([
+    [0, 0, 2],
+    [1, 0, 4],
+    [2, 0, 6],
+    [3, 0, 8],
+    [4, 0, 10],
+    [5, 0, 12],
+    [6, 0, 14],
+    [7, 0, 12],
+    [8, 0, 10],
+    [9, 0, 8],
+    [10, 0, 6],
+    [11, 0, 4],
+    [12, 0, 2]
+])
+
+REFERENCE_INPUT_WEIGHTED = np.array(
+    [
+        [
+            [0, 0, 735],
+            [0, 1, 45],
+            [0, 2, 125],
+            [0, 3, 167],
+            [1, 0, 450],
+            [1, 1, 337],
+            [1, 2, 95],
+            [1, 3, 245],
+            [2, 0, 124],
+            [2, 1, 430],
+            [2, 2, 230],
+            [2, 3, 460],
+            [3, 0, 75],
+            [3, 1, 20],
+            [3, 2, 32],
+            [3, 3, 20]
+        ],
+        [
+            [0, 0, 2],
+            [0, 1, 3],
+            [0, 2, 2],
+            [0, 3, 3],
+            [1, 0, 1],
+            [1, 1, 3],
+            [1, 2, 3],
+            [1, 3, 2],
+            [2, 0, 1],
+            [2, 1, 2],
+            [2, 2, 3],
+            [2, 3, 1],
+            [3, 0, 2],
+            [3, 1, 2],
+            [3, 2, 2],
+            [3, 3, 1]
+        ]]
+)
+
+# CONSTS
+STEP_SIZE = 1
+MAX_RANGE = 4
+BOUNDED_RANGE = (len(REFERENCE_INPUT_BOUNDED) / 2) - 1
+
+
+class TestEmpiricalSemivariance(unittest.TestCase):
+
+    def test_build_statistics_with_zeros(self):
+        variogram_stats = EmpiricalSemivariogram(
+            input_array=REFERENCE_INPUT_ZEROS,
+            step_size=STEP_SIZE,
+            max_range=MAX_RANGE
+        )
+
+        mean_semivar = np.mean(variogram_stats.experimental_semivariance[:, 1])
+        mean_covar = np.mean(variogram_stats.experimental_covariance[:, 1])
+        var_value = variogram_stats.variance
+
+        expected_value = 0
+
+        self.assertEqual(mean_semivar, expected_value)
+        self.assertEqual(mean_covar, expected_value)
+        self.assertEqual(var_value, expected_value)
+
+    def test_output_both(self):
+
+        variogram_stats = EmpiricalSemivariogram(
+            input_array=REFERENCE_INPUT_WE,
+            step_size=STEP_SIZE,
+            max_range=MAX_RANGE
+        )
+
+        # Check __str__() output
+
+        str_output = ''.join(variogram_stats.__str__().split())
+
+        expected_output = ''.join(
+            """+-----+--------------------+---------------------+--------------------+
+               | lag |    semivariance    |      covariance     |    var_cov_diff    |
+               +-----+--------------------+---------------------+--------------------+
+               | 1.0 |       4.625        | -0.5434027777777798 | 4.791923487836951  |
+               | 2.0 | 5.2272727272727275 | -0.7954545454545454 | 5.0439752555137165 |
+               | 3.0 |        6.0         | -1.2599999999999958 | 5.508520710059168  |
+               +-----+--------------------+---------------------+--------------------+""".split()
+        )
+
+        self.assertEqual(str_output, expected_output, msg='Expected __str__() output is different than '
+                                                          'the returned text')
+
+        # Check __repr__() output
+
+        new_variogram_stats = eval(variogram_stats.__repr__())
+        new_str_output = ''.join(new_variogram_stats.__str__().split())
+
+        self.assertEqual(new_str_output, expected_output, msg='Expected __str__() output is different than '
+                                                              'the returned __repr__() object text')
+
+    def test_single_output_semivariance(self):
+        variogram_stats = EmpiricalSemivariogram(
+            input_array=REFERENCE_INPUT_WE,
+            step_size=STEP_SIZE,
+            max_range=MAX_RANGE,
+            is_semivariance=True,
+            is_covariance=False,
+            is_variance=False
+        )
+        variogram = calculate_semivariance(
+            points=REFERENCE_INPUT_WE,
+            step_size=STEP_SIZE,
+            max_range=MAX_RANGE
+        )
+
+        are_equal = np.array_equal(variogram_stats.experimental_semivariance, variogram)
+        self.assertTrue(are_equal, msg='Semivariogram calculated with the EmpiricalSemivariogram class and '
+                                       'the calculate_semivariance() function must be the same!')
+
+        var_stats_str = ''.join(variogram_stats.__str__().split())
+        expected_str = ''.join(
+            """ +-----+--------------------+------------+--------------+
+                | lag |    semivariance    | covariance | var_cov_diff |
+                +-----+--------------------+------------+--------------+
+                | 1.0 |       4.625        |    nan     |     nan      |
+                | 2.0 | 5.2272727272727275 |    nan     |     nan      |
+                | 3.0 |        6.0         |    nan     |     nan      |
+                +-----+--------------------+------------+--------------+""".split()
+        )
+
+        self.assertEqual(var_stats_str, expected_str, msg='Expected __str__() output is different for semivariance'
+                                                          ' than the returned text')
+
+    def test_single_output_covariance(self):
+        variogram_stats = EmpiricalSemivariogram(
+            input_array=REFERENCE_INPUT_WE,
+            step_size=STEP_SIZE,
+            max_range=MAX_RANGE,
+            is_semivariance=False,
+            is_covariance=True,
+            is_variance=True
+        )
+        covariogram, variance = calculate_covariance(
+            points=REFERENCE_INPUT_WE,
+            step_size=STEP_SIZE,
+            max_range=MAX_RANGE,
+            get_c0=True
+        )
+
+        are_equal = np.array_equal(variogram_stats.experimental_covariance, covariogram)
+        self.assertTrue(are_equal, msg='Covariogram calculated with the EmpiricalSemivariogram class and '
+                                       'the calculate_covariance() function must be the same!')
+
+        self.assertEqual(variogram_stats.variance, variance, msg='Variances for the EmpiricalSemivariogram class'
+                                                                 ' and the calculate_covariance() function must'
+                                                                 ' be the same!')
+
+        var_stats_str = ''.join(variogram_stats.__str__().split())
+
+        expected_str = ''.join(
+            """ +-----+--------------+---------------------+--------------------+
+                | lag | semivariance |      covariance     |    var_cov_diff    |
+                +-----+--------------+---------------------+--------------------+
+                | 1.0 |     nan      | -0.5434027777777798 | 4.791923487836951  |
+                | 2.0 |     nan      | -0.7954545454545454 | 5.0439752555137165 |
+                | 3.0 |     nan      | -1.2599999999999958 | 5.508520710059168  |
+                +-----+--------------+---------------------+--------------------+""".split()
+        )
+
+        self.assertEqual(var_stats_str, expected_str, msg='Expected __str__() output is different for semivariance'
+                                                          ' than the returned text')
+
+    def test_build_variogram_stats(self):
+        exp_variogram = build_experimental_variogram(
+            input_array=REFERENCE_INPUT_WEIGHTED[0],
+            step_size=STEP_SIZE,
+            max_range=MAX_RANGE,
+            weights=REFERENCE_INPUT_WEIGHTED[1][:, -1]
+        )
+
+        variogram_stats = EmpiricalSemivariogram(
+            input_array=REFERENCE_INPUT_WEIGHTED[0],
+            step_size=STEP_SIZE,
+            max_range=MAX_RANGE,
+            weights=REFERENCE_INPUT_WEIGHTED[1][:, -1]
+        )
+
+        are_equal_semivariances = np.array_equal(
+            exp_variogram.experimental_semivariance, variogram_stats.experimental_semivariance
+        )
+
+        are_equal_covariances = np.array_equal(
+            exp_variogram.experimental_covariance, variogram_stats.experimental_covariance
+        )
+
+        are_equal_variances = np.equal(exp_variogram.variance, variogram_stats.variance)
+
+        # Assertions
+
+        self.assertTrue(are_equal_variances, msg='Output variance must be the same for EmpiricalSemivariogram class'
+                                                 ' and build_experimental_variogram() function.')
+        self.assertTrue(are_equal_covariances, msg='Output covariance must be the same for EmpiricalSemivariogram class'
+                                                   ' and build_experimental_variogram() function.')
+        self.assertTrue(are_equal_semivariances, msg='Output semivariance must be the same for EmpiricalSemivariogram '
+                                                     'class and build_experimental_variogram() function.')
+
+    def test_bounded_variogram(self):
+
+        bounded_variogram = build_experimental_variogram(
+            input_array=REFERENCE_INPUT_BOUNDED,
+            step_size=STEP_SIZE,
+            max_range=BOUNDED_RANGE
+        )
+
+        diff = bounded_variogram.variance - bounded_variogram.experimental_covariance[:, 1]
+        are_close = np.allclose(bounded_variogram.experimental_semivariance[:, 1],
+                                diff, rtol=2)
+
+        self.assertTrue(are_close, msg='Expeced difference c(0) - c(h) should be close to the '
+                                       'semivariances at y(h) for a given dataset.')

--- a/pyinterpolate/variogram/empirical/__init__.py
+++ b/pyinterpolate/variogram/empirical/__init__.py
@@ -1,0 +1,3 @@
+from .empirical_semivariogram import build_experimental_variogram, EmpiricalSemivariogram
+from .semivariance import calculate_semivariance
+from .covariance import calculate_covariance

--- a/pyinterpolate/variogram/empirical/empirical_semivariogram.py
+++ b/pyinterpolate/variogram/empirical/empirical_semivariogram.py
@@ -1,11 +1,149 @@
+import numpy as np
+from numpy import nan
+from prettytable import PrettyTable
 from pyinterpolate.variogram.empirical.covariance import calculate_covariance
 from pyinterpolate.variogram.empirical.semivariance import calculate_semivariance
 
 
 class EmpiricalSemivariogram:
+    """
+    Class calculates Experimental Semivariogram and Experimental Covariogram of a given dataset.
 
-    def __init__(self, input_array, step_size: float, max_range: float, weights=None, direction=0, tolerance=0,
-                 calculate_semivariance=True, calculate_covariance=False, get_variance_c0=False):
+    Parameters
+    ----------
+    input_array : numpy array
+                  coordinates and their values: (pt x, pt y, value) or (Point(), value).
+
+    step_size : float
+                distance between lags within each points are included in the calculations.
+
+    max_range : float
+                maximum range of analysis.
+
+    weights : numpy array or None, optional, default=None
+              weights assigned to points, index of weight must be the same as index of point, if provided then
+              the semivariogram is weighted.
+
+    direction : float (in range [0, 360]), optional, default=0
+                direction of semivariogram, values from 0 to 360 degrees:
+                * 0 or 180: is NS direction,
+                * 90 or 270 is EW direction,
+                * 45 or 225 is NE-SW direction,
+                * 135 or 315 is NW-SE direction.
+
+    tolerance : float (in range [0, 1]), optional, default=1
+                If tolerance is 0 then points must be placed at a single line with the beginning in the origin of
+                the coordinate system and the angle given by y axis and direction parameter. If tolerance is > 0 then
+                the bin is selected as an elliptical area with major axis pointed in the same direction as the line
+                for 0 tolerance.
+                * The minor axis size is (tolerance * step_size)
+                * The major axis size is ((1 - tolerance) * step_size)
+                * The baseline point is at a center of the ellipse.
+                Tolerance == 1 creates an omnidirectional semivariogram.
+
+    is_semivariance : bool, optional, default=True
+                      should semivariance be calculated?
+
+    is_covariance : bool, optional, default=True
+                    should covariance be calculated?
+
+    is_variance : bool, optional, default=True
+                  should variance be calculated?
+
+    Attributes
+    ----------
+    input_array : numpy array
+                  The array with coordinates and observed values.
+
+    experimental_semivariance : numpy array or None, optional, default=None
+                                The array of semivariance per lag in the form:
+                                (lag, semivariance, number of points within lag).
+
+    experimental_covariance : numpy array or None, optional, default=None
+                              The array of covariance per lag in the form:
+                              (lag, covariance, number of points within lag).
+
+    variance : float or None, optional, default=None
+               The variance of a dataset, if data is second-order stationary then we are able to retrieve a semivariance
+               as a difference between the variance and the experimental covariance:
+
+                    (Eq. 1)
+
+                        g(h) = c(0) - c(h)
+
+                        where:
+
+                        g(h): semivariance at a given lag h,
+                        c(0): variance of a dataset,
+                        c(h): covariance of a dataset.
+
+                Important! Have in mind that it works only if process is second-order stationary (variance is the same
+                for each distance bin) and if the semivariogram has the upper bound.
+
+    step : float
+        Derived from the step_size parameter.
+
+    mx_rng : float
+        Derived from the  max_range parameter.
+
+    weights : numpy array or None
+        Derived from the weights paramtere.
+
+    direct: float
+        Derived from the direction parameter.
+
+    tol : float
+        Derived from the tolerance parameter.
+
+    Methods
+    -------
+    __str__()
+        prints basic info about the class parameters.
+
+    __repr__()
+        reproduces class initialization with an input data.
+
+    See Also
+    --------
+    calculate_covariance : function to calculate experimental covariance and variance of a given set of points.
+    calculate_semivariance : function to calculate experimental semivariance from a given set of points.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> REFERENCE_INPUT = np.array([
+    ...    [0, 0, 8],
+    ...    [1, 0, 6],
+    ...    [2, 0, 4],
+    ...    [3, 0, 3],
+    ...    [4, 0, 6],
+    ...    [5, 0, 5],
+    ...    [6, 0, 7],
+    ...    [7, 0, 2],
+    ...    [8, 0, 8],
+    ...    [9, 0, 9],
+    ...    [10, 0, 5],
+    ...    [11, 0, 6],
+    ...    [12, 0, 3]
+    ...])
+    >>> STEP_SIZE = 1
+    >>> MAX_RANGE = 4
+    >>> empirical_smv = EmpiricalSemivariogram(REFERENCE_INPUT, step_size=STEP_SIZE, max_range=MAX_RANGE)
+    >>> print(empirical_smv)
+    +-----+--------------------+---------------------+--------------------+
+    | lag |    semivariance    |      covariance     |    var_cov_diff    |
+    +-----+--------------------+---------------------+--------------------+
+    | 1.0 |       4.625        | -0.5434027777777798 | 4.791923487836951  |
+    | 2.0 | 5.2272727272727275 | -0.7954545454545454 | 5.0439752555137165 |
+    | 3.0 |        6.0         | -1.2599999999999958 | 5.508520710059168  |
+    +-----+--------------------+---------------------+--------------------+
+    """
+
+    def __init__(self, input_array, step_size: float, max_range: float, weights=None, direction=0, tolerance=1,
+                 is_semivariance=True, is_covariance=True, is_variance=True):
+
+        if not isinstance(input_array, np.ndarray):
+            input_array = np.array(input_array)
 
         self.input_array = input_array
         self.experimental_semivariance = None
@@ -18,17 +156,21 @@ class EmpiricalSemivariogram:
         self.direct = direction
         self.tol = tolerance
 
-        if calculate_semivariance:
+        if is_semivariance:
             self._calculate_semivariance()
-        if calculate_covariance:
-            self._calculate_covariance(get_variance_c0)
+        if is_covariance:
+            self._calculate_covariance(is_variance)
 
-
-        self.is_semivariance = calculate_semivariance
-        self.is_covariance = calculate_covariance
-        self.is_variance = get_variance_c0
+        self.__c_sem = is_semivariance
+        self.__c_cov = is_covariance
+        self.__c_var = is_variance
 
     def _calculate_semivariance(self):
+        """
+        Method calculates semivariance.
+
+        See: calculate_semivariance function.
+        """
         self.experimental_semivariance = calculate_semivariance(
             points=self.input_array.copy(),
             step_size=self.step,
@@ -39,6 +181,11 @@ class EmpiricalSemivariogram:
         )
 
     def _calculate_covariance(self, get_variance=False):
+        """
+        Method calculates covariance and variance.
+
+        See : calculate_covariance function.
+        """
         self.experimental_covariance, self.variance = calculate_covariance(
             points=self.input_array.copy(),
             step_size=self.step,
@@ -47,3 +194,175 @@ class EmpiricalSemivariogram:
             tolerance=self.tol,
             get_c0=get_variance
         )
+
+    def __str_empty(self):
+        if not self.__c_var:
+            return "Empty object"
+        else:
+            return f"Variance: {self.variance:.4f}"
+
+    def __str_populate_both(self):
+        rows = []
+        if self.__c_var:
+            for idx, row in enumerate(self.experimental_semivariance):
+                lag = row[0]
+                smv = row[1]
+                cov = self.experimental_covariance[idx][1]
+                var_cov_diff = self.variance - cov
+                rows.append([lag, smv, cov, var_cov_diff])
+        else:
+            for idx, row in enumerate(self.experimental_semivariance):
+                lag = row[0]
+                smv = row[1]
+                cov = self.experimental_covariance[idx][1]
+                rows.append([lag, smv, cov, nan])
+        return rows
+
+    def __str_populate_single(self):
+        rows = []
+        if self.__c_cov:
+            if self.__c_var:
+                for row in self.experimental_covariance:
+                    lag = row[0]
+                    cov = row[1]
+                    var_cov_diff = self.variance - cov
+                    rows.append([lag, nan, cov, var_cov_diff])
+            else:
+                for row in self.experimental_covariance:
+                    lag = row[0]
+                    cov = row[1]
+                    rows.append([lag, nan, cov, nan])
+        else:
+            for row in self.experimental_semivariance:
+                lag = row[0]
+                sem = row[1]
+                rows.append([lag, sem, nan, nan])
+        return rows
+
+    def __str__(self):
+
+        pretty_table = PrettyTable()
+
+        pretty_table.field_names = ["lag", "semivariance", "covariance", "var_cov_diff"]
+
+        if not self.__c_sem and not self.__c_cov:
+            return self.__str_empty()
+        else:
+            if self.__c_sem and self.__c_cov:
+                pretty_table.add_rows(self.__str_populate_both())
+            else:
+                pretty_table.add_rows(self.__str_populate_single())
+            return pretty_table.get_string()
+
+    def __repr__(self):
+        cname = 'EmpiricalSemivariogram'
+        input_params = f'input_array={self.input_array.tolist()}, step_size={self.step}, max_range={self.mx_rng}, ' \
+                       f'weights={self.weights}, direction={self.direct}, tolerance={self.tol}, ' \
+                       f'is_semivariance={self.__c_sem}, is_covariance={self.__c_cov}, is_variance={self.__c_var}'
+        repr_val = cname + '(' + input_params + ')'
+        return repr_val
+
+
+def build_experimental_variogram(input_array,
+                                 step_size: float,
+                                 max_range: float,
+                                 weights=None,
+                                 direction=0,
+                                 tolerance=1) -> EmpiricalSemivariogram:
+    """
+    Function prepares:
+        - experimental semivariogram,
+        - experimental covariogram,
+        - variance.
+
+    Parameters
+    ----------
+    input_array : numpy array
+                  coordinates and their values: (pt x, pt y, value) or (Point(), value).
+
+    step_size : float
+                distance between lags within each points are included in the calculations.
+
+    max_range : float
+                maximum range of analysis.
+
+    weights : numpy array or None, optional, default=None
+              weights assigned to points, index of weight must be the same as index of point, if provided then
+              the semivariogram is weighted.
+
+    direction : float (in range [0, 360]), optional, default=0
+                direction of semivariogram, values from 0 to 360 degrees:
+                * 0 or 180: is NS direction,
+                * 90 or 270 is EW direction,
+                * 45 or 225 is NE-SW direction,
+                * 135 or 315 is NW-SE direction.
+
+    tolerance : float (in range [0, 1]), optional, default=1
+                If tolerance is 0 then points must be placed at a single line with the beginning in the origin of
+                the coordinate system and the angle given by y axis and direction parameter. If tolerance is > 0 then
+                the bin is selected as an elliptical area with major axis pointed in the same direction as the line
+                for 0 tolerance.
+                * The minor axis size is (tolerance * step_size)
+                * The major axis size is ((1 - tolerance) * step_size)
+                * The baseline point is at a center of the ellipse.
+                Tolerance == 1 creates an omnidirectional semivariogram.
+
+    Returns
+    -------
+    semivariogram_stats : EmpiricalSemivariogram
+        The class with empirical semivariogram, empirical covariogram and variance
+
+    See Also
+    --------
+    calculate_covariance : function to calculate experimental covariance and variance of a given set of points.
+    calculate_semivariance : function to calculate experimental semivariance from a given set of points.
+    EmpiricalSemivariogram : class that calculates and stores experimental semivariance, covariance and variance.
+
+    Notes
+    -----
+    Function is an alias for EmpiricalSemivariogram class and it forces calculations of all spatial statistics from a
+        given dataset.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> REFERENCE_INPUT = np.array([
+    ...    [0, 0, 8],
+    ...    [1, 0, 6],
+    ...    [2, 0, 4],
+    ...    [3, 0, 3],
+    ...    [4, 0, 6],
+    ...    [5, 0, 5],
+    ...    [6, 0, 7],
+    ...    [7, 0, 2],
+    ...    [8, 0, 8],
+    ...    [9, 0, 9],
+    ...    [10, 0, 5],
+    ...    [11, 0, 6],
+    ...    [12, 0, 3]
+    ...])
+    >>> STEP_SIZE = 1
+    >>> MAX_RANGE = 4
+    >>> empirical_smv = build_experimental_variogram(REFERENCE_INPUT, step_size=STEP_SIZE, max_range=MAX_RANGE)
+    >>> print(empirical_smv)
+    +-----+--------------------+---------------------+--------------------+
+    | lag |    semivariance    |      covariance     |    var_cov_diff    |
+    +-----+--------------------+---------------------+--------------------+
+    | 1.0 |       4.625        | -0.5434027777777798 | 4.791923487836951  |
+    | 2.0 | 5.2272727272727275 | -0.7954545454545454 | 5.0439752555137165 |
+    | 3.0 |        6.0         | -1.2599999999999958 | 5.508520710059168  |
+    +-----+--------------------+---------------------+--------------------+
+
+    """
+    semivariogram_stats = EmpiricalSemivariogram(
+        input_array=input_array,
+        step_size=step_size,
+        max_range=max_range,
+        weights=weights,
+        direction=direction,
+        tolerance=tolerance,
+        is_semivariance=True,
+        is_covariance=True,
+        is_variance=True
+    )
+    return semivariogram_stats

--- a/pyinterpolate/variogram/empirical/empirical_semivariogram.py
+++ b/pyinterpolate/variogram/empirical/empirical_semivariogram.py
@@ -1,2 +1,49 @@
+from pyinterpolate.variogram.empirical.covariance import calculate_covariance
+from pyinterpolate.variogram.empirical.semivariance import calculate_semivariance
+
+
 class EmpiricalSemivariogram:
-    pass
+
+    def __init__(self, input_array, step_size: float, max_range: float, weights=None, direction=0, tolerance=0,
+                 calculate_semivariance=True, calculate_covariance=False, get_variance_c0=False):
+
+        self.input_array = input_array
+        self.experimental_semivariance = None
+        self.experimental_covariance = None
+        self.variance = None
+
+        self.step = step_size
+        self.mx_rng = max_range
+        self.weights = weights
+        self.direct = direction
+        self.tol = tolerance
+
+        if calculate_semivariance:
+            self._calculate_semivariance()
+        if calculate_covariance:
+            self._calculate_covariance(get_variance_c0)
+
+
+        self.is_semivariance = calculate_semivariance
+        self.is_covariance = calculate_covariance
+        self.is_variance = get_variance_c0
+
+    def _calculate_semivariance(self):
+        self.experimental_semivariance = calculate_semivariance(
+            points=self.input_array.copy(),
+            step_size=self.step,
+            max_range=self.mx_rng,
+            weights=self.weights,
+            direction=self.direct,
+            tolerance=self.tol
+        )
+
+    def _calculate_covariance(self, get_variance=False):
+        self.experimental_covariance, self.variance = calculate_covariance(
+            points=self.input_array.copy(),
+            step_size=self.step,
+            max_range=self.mx_rng,
+            direction=self.direct,
+            tolerance=self.tol,
+            get_c0=get_variance
+        )

--- a/pyinterpolate/variogram/empirical/semivariance.py
+++ b/pyinterpolate/variogram/empirical/semivariance.py
@@ -103,7 +103,7 @@ def _calculate_weighted_directional_semivariogram(points: np.array,
         and baseline point at a center of ellipse. Tolerance == 1 (normalized to 0.5) creates omnidirectional
         semivariogram.
 
-    :returns: (np.array)
+    :return: (numpy array) [lag, semivariance, number of points within lag]
     """
 
     semivariances_and_lags = list()
@@ -187,7 +187,7 @@ def directional_semivariogram(points: np.array,
         and baseline point at a center of ellipse. Tolerance == 1 (normalized to 0.5) creates omnidirectional
         semivariogram.
 
-    :returns: (np.array)
+    :return: (numpy array) [lag, semivariance, number of points within lag]
     """
 
     if weights is None:
@@ -352,7 +352,7 @@ def calculate_semivariance(points: np.array,
 
     # TODO
 
-
+    :return: (numpy array) [lag, semivariance, number of points within lag]
     """
 
     # START:VALIDATION


### PR DESCRIPTION
# `EmpiricalSemivariogram` class and `build_experimental_variogram()` function

## Package version (main branch)
version: **0.3.0**

## Description
**Feature**s:
- `EmpiricalSemivariogram`: Class calculates Experimental Semivariogram and Experimental Covariogram of a given dataset.
- `build_experimental_variogram()`: Function prepares the experimental semivariogram, experimental covariogram, and a variance of an input dataset.

## Problem
n/a

## Solution
n/a

### Affected modules

-variogram

### Unit tests

- `test_build_statistics_with_zeros`,
- `test_output_both`,
- `test_single_output_semivariance`,
- `test_single_output_covariance`,
- `test_build_variogram_stats`,
- `test_bounded_variogram`

### Package check

- [x] All tests passed
- [-] Documentation updated
- [-] All tutorials are working properly

### (Optional) Additional info
The feature is based on the literature. More emphasis is taken on the semivariogram preparation and monitoring its properties.


