### PR TITLE
updated control over NaNs in experimental variograms

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -6,6 +6,13 @@ Pyinterpolate is the Python library for **geostatistics**. The package provides 
 Changes by date
 ===============
 
+2022-XX-XX
+----------
+
+**version 0.3.1**
+
+* experimental variogram, covariogram, and variogram cloud function and classes check if there are NaN's in the input data and raise `ValueError`
+
 2022-09-04
 ----------
 
@@ -25,7 +32,7 @@ Changes by date
 * data structures are more complex, but they allow user to be more flexible with an input.
 
 
-2021-12-XX
+2021-12-31
 ----------
 
 **version 0.2.5**

--- a/pyinterpolate/test/test_variogram/empirical/test_cloud.py
+++ b/pyinterpolate/test/test_variogram/empirical/test_cloud.py
@@ -90,6 +90,19 @@ class TestVariogramPointCloud(unittest.TestCase):
                   f'the NE-SW direction.'
         self.assertAlmostEqual(smv, expected_output, places=2, msg=err_msg)
 
+    def test_raises_value_error(self):
+        pts = np.array([[0, 0, np.nan], [1, 1, 2]])
+
+        kwargs = {
+            'input_array': pts,
+            'step_size': 1,
+            'max_range': 3,
+            'direction': 45,
+            'tolerance': 0.5
+        }
+
+        self.assertRaises(ValueError, build_variogram_point_cloud, **kwargs)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyinterpolate/test/test_variogram/empirical/test_covariance.py
+++ b/pyinterpolate/test/test_variogram/empirical/test_covariance.py
@@ -105,6 +105,20 @@ class TestCovariance(unittest.TestCase):
                   f'the NE-SW direction.'
         self.assertAlmostEqual(lag1_test_value, expected_output, places=2, msg=err_msg)
 
+    def test_raises_value_error(self):
+        pts = np.array([[0, 0, np.nan], [1, 1, 2]])
+
+        kwargs = {
+            'points': pts,
+            'step_size': 1,
+            'max_range': 3,
+            'direction': 45,
+            'tolerance': 0.5,
+            'get_c0': False
+        }
+
+        self.assertRaises(ValueError, calculate_covariance, **kwargs)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyinterpolate/test/test_variogram/empirical/test_empirical_variance_class.py
+++ b/pyinterpolate/test/test_variogram/empirical/test_empirical_variance_class.py
@@ -190,3 +190,16 @@ class TestEmpiricalSemivariance(unittest.TestCase):
 
         self.assertTrue(are_close, msg='Expeced difference c(0) - c(h) should be close to the '
                                        'semivariances at y(h) for a given dataset.')
+
+    def test_raises_value_error(self):
+        pts = np.array([[0, 0, np.nan], [1, 1, 2]])
+
+        kwargs = {
+            'input_array': pts,
+            'step_size': 1,
+            'max_range': 3,
+            'direction': 45,
+            'tolerance': 0.5
+        }
+
+        self.assertRaises(ValueError, ExperimentalVariogram, **kwargs)

--- a/pyinterpolate/test/test_variogram/empirical/test_semivariance.py
+++ b/pyinterpolate/test/test_variogram/empirical/test_semivariance.py
@@ -115,6 +115,21 @@ class TestSemivariance(unittest.TestCase):
                   f'{expected_output} and calculated output is {smv}'
         self.assertTrue(arr_check, err_msg)
 
+    ### RAISES
+
+    def test_raises_value_error(self):
+        pts = np.array([[0, 0, np.nan], [1, 1, 2]])
+
+        kwargs = {
+            'points': pts,
+            'step_size': 1,
+            'max_range': 3,
+            'direction': 45,
+            'tolerance': 0.5
+        }
+
+        self.assertRaises(ValueError, calculate_semivariance, **kwargs)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyinterpolate/test/test_variogram/empirical/test_variogram_cloud_class.py
+++ b/pyinterpolate/test/test_variogram/empirical/test_variogram_cloud_class.py
@@ -121,4 +121,17 @@ class TestEmpiricalSemivariance(unittest.TestCase):
                          new_cloud.describe(),
                          msg=msg)
 
+    def test_raises_value_error(self):
+        pts = np.array([[0, 0, np.nan], [1, 1, 2]])
+
+        kwargs = {
+            'input_array': pts,
+            'step_size': 1,
+            'max_range': 3,
+            'direction': 45,
+            'tolerance': 0.5
+        }
+
+        self.assertRaises(ValueError, VariogramCloud, **kwargs)
+
     # TODO: test plots (future)

--- a/pyinterpolate/variogram/empirical/cloud.py
+++ b/pyinterpolate/variogram/empirical/cloud.py
@@ -136,8 +136,8 @@ def directional_point_cloud(input_array: np.array,
 def build_variogram_point_cloud(input_array: np.array,
                                 step_size: float,
                                 max_range: float,
-                                direction=0,
-                                tolerance=1) -> dict:
+                                direction=0.0,
+                                tolerance=1.0) -> dict:
     """
     Function calculates lagged variogram point cloud. Variogram is calculated as a squared difference of each point
         against other point within range specified by step_size parameter.
@@ -317,6 +317,9 @@ class VariogramCloud:
 
         if not isinstance(input_array, np.ndarray):
             input_array = np.array(input_array)
+
+        # Validate input array
+        validate_points(input_array)
 
         self.input_array = input_array
         self.experimental_point_cloud = None

--- a/pyinterpolate/variogram/empirical/experimental_variogram.py
+++ b/pyinterpolate/variogram/empirical/experimental_variogram.py
@@ -178,6 +178,7 @@ class ExperimentalVariogram:
                  is_variance=True):
 
         self.input_array = None  # core structure
+
         if isinstance(input_array, np.ndarray):
             self.input_array = input_array
         else:

--- a/pyinterpolate/variogram/utils/exceptions.py
+++ b/pyinterpolate/variogram/utils/exceptions.py
@@ -7,6 +7,8 @@ Authors
 """
 import warnings
 
+import numpy as np
+
 
 class MetricsTypeSelectionError(Exception):
     """Error invoked if user doesn't select any error type for the theoretical variogram modeling.
@@ -90,13 +92,18 @@ def validate_direction(direction):
 
 def validate_points(points):
     """
-    Check dimensions of provided arrays and data types.
+    * Check dimensions of provided arrays and data types.
+    * Check if there are any NaN values.
     """
 
     dims = points.shape
     msg = 'Provided array must have 3 columns: [x, y, value]'
     if dims[1] != 3:
         raise AttributeError(msg)
+
+    if np.isnan(points[:, -1]).any():
+        msg = 'Provided dataset contains NaNs, remove records with missing values before processing'
+        raise ValueError(msg)
 
 
 def validate_tolerance(tolerance):


### PR DESCRIPTION
# Raise `ValueError` when `NaN` is passed into experimental variogram classes and functions

## Package version (main branch)
version: **0.3.0**

## Description
Raise `ValueError` when `NaN` is passed into experimental variogram classes and functions

## Problem
Passed `NaN` values may influence variogram modeling and analysis.

## Solution
Raise `ValueError` and force the user to clean data before analysis.

### Affected modules

- `variogram`

### Unit tests

- every test from experimental variogram,

### Package check

- [x] All tests passed
- [x] Documentation updated
- [x] All tutorials are working properly

### (Optional) Additional info
n/a


