### PR TITLE
Dev tol calc dir variogram

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -11,7 +11,8 @@ Changes by date
 
 **version 0.3.1**
 
-* experimental variogram, covariogram, and variogram cloud function and classes check if there are NaN's in the input data and raise `ValueError`
+* experimental variogram, covariogram, and variogram cloud function and classes check if there are NaN's in the input data and raise `ValueError`,
+* the length of major and minor axes of a directional variogram ellipsis are calculated differently from the `tolerance` parameter, (now we have a less of chaos),
 
 2022-09-04
 ----------

--- a/pyinterpolate/test/test_processing/test_select_values.py
+++ b/pyinterpolate/test/test_processing/test_select_values.py
@@ -80,22 +80,16 @@ class TestDirectionalSelection(unittest.TestCase):
                 self.assertTrue(is_point_equal, msg=err_msg)
 
     def test_NE_SW_selection(self):
-        points = [
-            [2, 2]
-        ]
-        selections = []
-        for pt in points:
-            selection = select_points_within_ellipse(ellipse_center=pt,
-                                                     other_points=INPUT_ARRAY[:, :-1],
-                                                     lag=3,
-                                                     step_size=1,
-                                                     theta=45,
-                                                     minor_axis_size=0.01)
-            output = INPUT_ARRAY[selection]
-            selections.append(output)
-        for idx, unit_output in enumerate(selections):
-            expected = EXPECTED_NE_SW
-            is_point_equal = np.equal(unit_output, expected).all()
-            err_msg = f'Points in direction NW-SE and one step away from the third column were not detected!' \
-                      f' Wrong point is: {unit_output[:-1]}'
-            self.assertTrue(is_point_equal, msg=err_msg)
+        point = np.array([2, 2])
+        selection = select_points_within_ellipse(ellipse_center=point,
+                                                 other_points=INPUT_ARRAY[:, :-1],
+                                                 lag=3,
+                                                 step_size=1,
+                                                 theta=45,
+                                                 minor_axis_size=0.01)
+        output = INPUT_ARRAY[selection]
+
+        is_point_equal = np.equal(output, EXPECTED_NE_SW).all()
+        err_msg = f'Points in direction NW-SE and one step away from the third column were not detected!' \
+                 f' Wrong point is: {output}'
+        self.assertTrue(is_point_equal, msg=err_msg)

--- a/pyinterpolate/test/test_variogram/empirical/test_cloud.py
+++ b/pyinterpolate/test/test_variogram/empirical/test_cloud.py
@@ -62,8 +62,8 @@ class TestVariogramPointCloud(unittest.TestCase):
                                            step_size=1,
                                            max_range=2,
                                            direction=90,
-                                           tolerance=0.1)
-        lag1_test_values = next(iter(smvs.items()))[1]
+                                           tolerance=0.01)
+        lag1_test_values = smvs[1]
         smv = np.mean(lag1_test_values) / 2
 
         expected_output = sem_data.output_armstrong_we_lag1
@@ -78,13 +78,13 @@ class TestVariogramPointCloud(unittest.TestCase):
                                            direction=45,
                                            tolerance=0.01)
 
-        lag2_test_values = np.nan  # It will throw error when no assigned
+        lagx_test_values = np.nan  # It will throw error when no assigned
         for lag, values in smvs.items():
             if lag == 2:
-                lag2_test_values = values.copy()
+                lagx_test_values = values.copy()
                 break
 
-        smv = np.mean(lag2_test_values) / 2
+        smv = np.mean(lagx_test_values) / 2
         expected_output = sem_data.output_armstrong_ne_sw_lag2
         err_msg = f'Calculated semivariance for lag 1 should be equal to {expected_output} for ' \
                   f'the NE-SW direction.'

--- a/pyinterpolate/variogram/empirical/cloud.py
+++ b/pyinterpolate/variogram/empirical/cloud.py
@@ -85,15 +85,13 @@ def directional_point_cloud(input_array: np.array,
                 * 45 or 225 is NE-SW direction,
                 * 135 or 315 is NW-SE direction.
 
-    tolerance : float (in range [0, 1])
-                If tolerance is 0 then points must be placed at a single line with the beginning in the origin of
-                the coordinate system and the angle given by y axis and direction parameter. If tolerance is > 0 then
-                the bin is selected as an elliptical area with major axis pointed in the same direction as the line
-                for 0 tolerance.
-                * The minor axis size is (tolerance * step_size)
-                * The major axis size is ((1 - tolerance) * step_size)
-                * The baseline point is at a center of the ellipse.
-                Tolerance == 1 creates an omnidirectional semivariogram.
+    tolerance : float, default=1
+                Value in range (0-1] to calculate semi-minor axis length of the search area. If tolerance is close
+                to 0 then points must be placed at a single line with beginning in the origin of coordinate system
+                and angle given by y axis and direction parameter.
+                    * The major axis length == step_size,
+                    * The minor axis size == tolerance * step_size.
+                    * Tolerance == 1 creates the omnidirectional semivariogram.
 
     Returns
     -------
@@ -160,15 +158,13 @@ def build_variogram_point_cloud(input_array: np.array,
                 * 45 or 225 is NE-SW direction,
                 * 135 or 315 is NW-SE direction.
 
-    tolerance : float (in range [0, 1]), optional, default=1
-                If tolerance is 0 then points must be placed at a single line with the beginning in the origin of
-                the coordinate system and the angle given by y axis and direction parameter. If tolerance is > 0 then
-                the bin is selected as an elliptical area with major axis pointed in the same direction as the line
-                for 0 tolerance.
-                * The minor axis size is (tolerance * step_size)
-                * The major axis size is ((1 - tolerance) * step_size)
-                * The baseline point is at a center of the ellipse.
-                Tolerance == 1 creates an omnidirectional semivariogram.
+    tolerance : float, default=1
+                Value in range (0-1] to calculate semi-minor axis length of the search area. If tolerance is close
+                to 0 then points must be placed at a single line with beginning in the origin of coordinate system
+                and angle given by y axis and direction parameter.
+                    * The major axis length == step_size,
+                    * The minor axis size == tolerance * step_size.
+                    * Tolerance == 1 creates the omnidirectional semivariogram.
 
     Returns
     -------
@@ -220,15 +216,13 @@ class VariogramCloud:
                 * 45 or 225 is NE-SW direction,
                 * 135 or 315 is NW-SE direction.
 
-    tolerance : float (in range [0, 1]), optional, default=1
-                If tolerance is 0 then points must be placed at a single line with the beginning in the origin of
-                the coordinate system and the angle given by y axis and direction parameter. If tolerance is > 0 then
-                the bin is selected as an elliptical area with major axis pointed in the same direction as the line
-                for 0 tolerance.
-                * The minor axis size is (tolerance * step_size)
-                * The major axis size is ((1 - tolerance) * step_size)
-                * The baseline point is at a center of the ellipse.
-                Tolerance == 1 creates an omnidirectional semivariogram.
+    tolerance : float, default=1
+                Value in range (0-1] to calculate semi-minor axis length of the search area. If tolerance is close
+                to 0 then points must be placed at a single line with beginning in the origin of coordinate system
+                and angle given by y axis and direction parameter.
+                    * The major axis length == step_size,
+                    * The minor axis size == tolerance * step_size.
+                    * Tolerance == 1 creates the omnidirectional semivariogram.
 
     Attributes
     ----------

--- a/pyinterpolate/variogram/empirical/covariance.py
+++ b/pyinterpolate/variogram/empirical/covariance.py
@@ -109,17 +109,13 @@ def directional_covariogram(points: np.array,
                     - 45 or 225 is NE-SW,
                     - 135 or 315 is NW-SE.
 
-    tolerance : float
-                Value in range (0-1) normalized to [0 : 0.5] to select tolerance of covariogram. If tolerance
-                is 0 then points must be placed at a single line with beginning in the origin of coordinate system
-                and angle given by y axis and direction parameter. If tolerance is greater than 0 then
-                covariance is estimated from elliptical area with major axis with the same direction as the line
-                for 0 tolerance and minor axis of a size:
-                    (tolerance * step_size)
-                and major axis (pointed in NS direction):
-                    ((1 - tolerance) * step_size)
-                and baseline point at a center of ellipse. Tolerance == 1 (normalized to 0.5) creates omnidirectional
-                covariogram.
+    tolerance : float, default=1
+                Value in range (0-1] to calculate semi-minor axis length of the search area. If tolerance is close
+                to 0 then points must be placed at a single line with beginning in the origin of coordinate system
+                and angle given by y axis and direction parameter.
+                    * The major axis length == step_size,
+                    * The minor axis size == tolerance * step_size.
+                    * Tolerance == 1 creates the omnidirectional covariogram.
 
     Returns
     -------
@@ -195,17 +191,13 @@ def calculate_covariance(points: np.array,
                     - 45 or 225 is NE-SW,
                     - 135 or 315 is NW-SE.
 
-    tolerance : float
-                Value in range (0-1) normalized to [0 : 0.5] to select tolerance of covariogram. If tolerance
-                is 0 then points must be placed at a single line with beginning in the origin of coordinate system
-                and angle given by y axis and direction parameter. If tolerance is greater than 0 then
-                covariance is estimated from elliptical area with major axis with the same direction as the line
-                for 0 tolerance and minor axis of a size:
-                    (tolerance * step_size)
-                and major axis (pointed in NS direction):
-                    ((1 - tolerance) * step_size)
-                and baseline point at a center of ellipse. Tolerance == 1 (normalized to 0.5) creates omnidirectional
-                covariogram.
+    tolerance : float, default=1
+                Value in range (0-1] to calculate semi-minor axis length of the search area. If tolerance is close
+                to 0 then points must be placed at a single line with beginning in the origin of coordinate system
+                and angle given by y axis and direction parameter.
+                    * The major axis length == step_size,
+                    * The minor axis size == tolerance * step_size.
+                    * Tolerance == 1 creates the omnidirectional covariogram.
 
     get_c0 : bool, default=True
              Calculate variance of a dataset and return it.

--- a/pyinterpolate/variogram/empirical/experimental_variogram.py
+++ b/pyinterpolate/variogram/empirical/experimental_variogram.py
@@ -45,15 +45,13 @@ class ExperimentalVariogram:
                 * 45 or 225 is NE-SW direction,
                 * 135 or 315 is NW-SE direction.
 
-    tolerance : float (in range [0, 1]), optional, default=1
-                If tolerance is 0 then points must be placed at a single line with the beginning in the origin of
-                the coordinate system and the angle given by y axis and direction parameter. If tolerance is > 0 then
-                the bin is selected as an elliptical area with major axis pointed in the same direction as the line
-                for 0 tolerance.
-                * The minor axis size is (tolerance * step_size)
-                * The major axis size is ((1 - tolerance) * step_size)
-                * The baseline point is at a center of the ellipse.
-                Tolerance == 1 creates an omnidirectional semivariogram.
+    tolerance : float, default=1
+                Value in range (0-1] to calculate semi-minor axis length of the search area. If tolerance is close
+                to 0 then points must be placed at a single line with beginning in the origin of coordinate system
+                and angle given by y axis and direction parameter.
+                    * The major axis length == step_size,
+                    * The minor axis size == tolerance * step_size.
+                    * Tolerance == 1 creates the omnidirectional semivariogram.
 
     is_semivariance : bool, optional, default=True
                       should semivariance be calculated?

--- a/pyinterpolate/variogram/empirical/semivariance.py
+++ b/pyinterpolate/variogram/empirical/semivariance.py
@@ -110,17 +110,13 @@ def _calculate_weighted_directional_semivariogram(points: np.array,
                     - 45 or 225 is NE-SW,
                     - 135 or 315 is NW-SE.
 
-    tolerance : float
-                Value in range (0-1) normalized to [0 : 0.5] to select tolerance of semivariogram. If tolerance
-                is 0 then points must be placed at a single line with beginning in the origin of coordinate system
-                and angle given by y axis and direction parameter. If tolerance is greater than 0 then
-                semivariance is estimated from elliptical area with major axis with the same direction as the line
-                for 0 tolerance and minor axis of a size:
-                    (tolerance * step_size)
-                and major axis (pointed in NS direction):
-                    ((1 - tolerance) * step_size)
-                and baseline point at a center of ellipse. Tolerance == 1 (normalized to 0.5) creates omnidirectional
-                semivariogram.
+    tolerance : float, default=1
+                Value in range (0-1] to calculate semi-minor axis length of the search area. If tolerance is close
+                to 0 then points must be placed at a single line with beginning in the origin of coordinate system
+                and angle given by y axis and direction parameter.
+                    * The major axis length == step_size,
+                    * The minor axis size == tolerance * step_size.
+                    * Tolerance == 1 creates the omnidirectional semivariogram.
 
     Returns
     -------

--- a/pyinterpolate/variogram/empirical/semivariance.py
+++ b/pyinterpolate/variogram/empirical/semivariance.py
@@ -208,17 +208,13 @@ def directional_semivariogram(points: np.array,
                     - 45 or 225 is NE-SW,
                     - 135 or 315 is NW-SE.
 
-    tolerance : float
-                Value in range (0-1) normalized to [0 : 0.5] to select tolerance of semivariogram. If tolerance
-                is 0 then points must be placed at a single line with beginning in the origin of coordinate system
-                and angle given by y axis and direction parameter. If tolerance is greater than 0 then
-                semivariance is estimated from elliptical area with major axis with the same direction as the line
-                for 0 tolerance and minor axis of a size:
-                    (tolerance * step_size)
-                and major axis (pointed in NS direction):
-                    ((1 - tolerance) * step_size)
-                and baseline point at a center of ellipse. Tolerance == 1 (normalized to 0.5) creates omnidirectional
-                semivariogram.
+    tolerance : float, default=1
+                Value in range (0-1] to calculate semi-minor axis length of the search area. If tolerance is close
+                to 0 then points must be placed at a single line with beginning in the origin of coordinate system
+                and angle given by y axis and direction parameter.
+                    * The major axis length == step_size,
+                    * The minor axis size == tolerance * step_size.
+                    * Tolerance == 1 creates the omnidirectional semivariogram.
 
     Returns
     -------
@@ -297,16 +293,12 @@ def calculate_semivariance(points: np.array,
                     - 135 or 315 is NW-SE.
 
     tolerance : float, default=1
-                Value in range (0-1) normalized to [0 : 0.5] to select tolerance of semivariogram. If tolerance
-                is 0 then points must be placed at a single line with beginning in the origin of coordinate system
-                and angle given by y axis and direction parameter. If tolerance is greater than 0 then
-                semivariance is estimated from elliptical area with major axis with the same direction as the line
-                for 0 tolerance and minor axis of a size:
-                    (tolerance * step_size)
-                and major axis (pointed in NS direction):
-                    ((1 - tolerance) * step_size)
-                and baseline point at a center of ellipse. Tolerance == 1 (normalized to 0.5) creates omnidirectional
-                semivariogram.
+                Value in range (0-1] to calculate semi-minor axis length of the search area. If tolerance is close
+                to 0 then points must be placed at a single line with beginning in the origin of coordinate system
+                and angle given by y axis and direction parameter.
+                    * The major axis length == step_size,
+                    * The minor axis size == tolerance * step_size.
+                    * Tolerance == 1 creates the omnidirectional semivariogram.
 
     Returns
     -------

--- a/pyinterpolate/variogram/utils/exceptions.py
+++ b/pyinterpolate/variogram/utils/exceptions.py
@@ -110,8 +110,8 @@ def validate_tolerance(tolerance):
     """
     Check if tolerance is between zero and one.
     """
-    if tolerance < 0 or tolerance > 1:
-        msg = 'Provided tolerance should be between 0 (straight line) and 1 (circle).'
+    if tolerance <= 0 or tolerance > 1:
+        msg = 'Provided tolerance should be larger than 0 (a straight line) and smaller or equal to 1 (a circle).'
         raise ValueError(msg)
 
 


### PR DESCRIPTION
# Updated calculations of the length of minor and major axes of directional variogram ellipsis

## Package version (main branch)
version: **0.3.0**

## Description
```
tolerance : float, default=1
                Value in range (0-1] to calculate semi-minor axis length of the search area. If tolerance is close
                to 0 then points must be placed at a single line with beginning in the origin of coordinate system
                and angle given by y axis and direction parameter.
                    * The major axis length == step_size,
                    * The minor axis size == tolerance * step_size.
                    * Tolerance == 1 creates the omnidirectional semivariogram.
```

## Problem
#285 - problem description

## Solution
major axis size = 1; minor axis size = `tolerance`

### Affected modules

- `variogram.empirical`
- `processing`

### Unit tests

- `select_values`
- `variogram`

### Package check

- [x] All tests passed
- [x] Documentation updated
- [x] All tutorials are working properly

### (Optional) Additional info
n/a


