### PR TITLE
model selection during deconvolution process

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -6,6 +6,12 @@ Pyinterpolate is the Python library for **geostatistics**. The package provides 
 Changes by date
 ===============
 
+2022-10-XX
+----------
+
+* Semivariogram `Deconvolution` takes possible model types to test,
+*
+
 2022-10-08
 ----------
 


### PR DESCRIPTION
# Added model selection during the deconvolution process

## Package version (main branch)
version: **0.3.2**

## Description
`Deconvolution` class has used all available theoretical variogram models, now users may select models to test.

## Problem
The algorithm has favored complex models (cubic, exponential and circular) over simpler and more stable techniques.

## Solution
Give user a chance to choose a model type to fit into data.

### Affected modules

- variogram

### Unit tests

- n/a

### Package check

- [x] All tests passed
- [-] Documentation updated
- [x] All tutorials are working properly

### (Optional) Additional info
n/a


