### PR TITLE
Control zero div directional

### DIFF
--- a/pyinterpolate/processing/select_values.py
+++ b/pyinterpolate/processing/select_values.py
@@ -8,7 +8,6 @@ Authors
 from typing import Iterable, Dict, Union, Tuple, List
 
 import geopandas as gpd
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 

--- a/pyinterpolate/test/debug_sandbox/directional_variogram_div_by_zero_warning.py
+++ b/pyinterpolate/test/debug_sandbox/directional_variogram_div_by_zero_warning.py
@@ -1,0 +1,19 @@
+# Issue: https://github.com/DataverseLabs/pyinterpolate/issues/213
+from pyinterpolate import read_txt, build_experimental_variogram
+
+
+DEM = '../samples/point_data/txt/pl_dem.txt'
+SEARCH_RADIUS = 0.1
+MAX_RANGE = 0.32
+DIRECTION = 150
+TOLERANCE = 0.1
+
+
+if __name__ == '__main__':
+    ds = read_txt(DEM)
+    exp_var = build_experimental_variogram(ds,
+                                           step_size=SEARCH_RADIUS,
+                                           max_range=MAX_RANGE,
+                                           direction=DIRECTION,
+                                           tolerance=TOLERANCE,
+                                           method='e')

--- a/pyinterpolate/variogram/empirical/semivariance.py
+++ b/pyinterpolate/variogram/empirical/semivariance.py
@@ -252,8 +252,6 @@ def _from_ellipse_non_weighted(points: np.array, lags: np.array, step_size: floa
             else:
                 msg = f'There are no neighbors for a lag {h}, the process has been stopped.'
                 raise RuntimeError(msg)
-            # TODO: remove comment below after tests
-            # semivariances_and_lags.append([h, 0, 0])
         else:
             average_semivariance = np.mean(semivars_per_lag) / 2
             semivariances_and_lags.append([h, average_semivariance, len(semivars_per_lag)])


### PR DESCRIPTION
# Functional test to check warning with zero division in directional variogram

## Package version (main branch)
version: **0.3.3**

## Description
Checked zero division warning in the elliptical selection of points within directional variogram.

## Problem
The algorithm should control zeros that may occur in a denominator.

## Solution
The code has changed, and the warning doesn't occur.

### Affected modules

- variogram
- test

### Unit tests

- `pyinterpolate/test/debug_sandbox/directional_variogram_div_by_zero_warning.py`

### Package check

- [x] All tests passed
- [x] Documentation updated
- [x] All tutorials are working properly

### (Optional) Additional info
n/a


