### PR TITLE
Ordinary Kriging from covariance terms

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -6,7 +6,7 @@ Pyinterpolate is the Python library for **geostatistics** and **spatial statisti
 Changes by date
 ===============
 
-2022-12-XX
+2023-01-XX
 ----------
 
 **version 0.3.6**
@@ -15,7 +15,8 @@ Changes by date
 * (debug) Added origin (unknown point) to calculate directional Kriging and directional Centroid-based Poisson Kriging,
 * (docs) Directional Ordinary Kriging tutorial,
 * (engancement) logging of area to area PK function,
-* (enhancement) `test` package moved outside the main package,
+* (enhancement) `tests` package moved outside the main package,
+* (feature) ordinary kriging from covariance terms,
 
 
 2022-11-05

--- a/pyinterpolate/kriging/models/point/ordinary_kriging.py
+++ b/pyinterpolate/kriging/models/point/ordinary_kriging.py
@@ -13,6 +13,7 @@ import numpy as np
 
 # Pyinterpolate
 from pyinterpolate.kriging.utils.process import get_predictions, solve_weights
+from pyinterpolate.processing.transform.transform import sem_to_cov
 from pyinterpolate.variogram import TheoreticalVariogram
 
 
@@ -92,6 +93,96 @@ def ordinary_kriging(
     zhat = dataset[:, -2].dot(output_weights[:-1])
 
     sigma = np.matmul(output_weights.T, k)
+
+    if sigma < 0:
+        return [zhat, np.nan, unknown_location[0], unknown_location[1]]
+
+    return [zhat, sigma, unknown_location[0], unknown_location[1]]
+
+
+def ordinary_kriging_from_cov(
+        theoretical_model: TheoreticalVariogram,
+        known_locations: np.ndarray,
+        unknown_location: Union[List, Tuple, np.ndarray],
+        sill,
+        neighbors_range=None,
+        no_neighbors=4,
+        use_all_neighbors_in_range=False,
+        allow_approximate_solutions=False
+) -> List:
+    """
+    Function predicts value at unknown location with Ordinary Kriging technique.
+
+    Parameters
+    ----------
+    theoretical_model : TheoreticalVariogram
+        A trained theoretical variogram model.
+
+    known_locations : numpy array
+        The known locations.
+
+    unknown_location : Union[List, Tuple, numpy array]
+        Point where you want to estimate value ``(x, y) <-> (lon, lat)``.
+
+    sill : float
+        The sill (``c(0)``) of a dataset.
+
+    neighbors_range : float, default=None
+        The maximum distance where we search for neighbors. If ``None`` is given then range is selected from
+        the ``theoretical_model`` ``rang`` attribute.
+
+    no_neighbors : int, default = 4
+        The number of the **n-closest neighbors** used for interpolation.
+
+    use_all_neighbors_in_range : bool, default = False
+        ``True``: if the real number of neighbors within the ``neighbors_range`` is greater than the
+        ``number_of_neighbors`` parameter then take all of them anyway.
+
+    allow_approximate_solutions : bool, default=False
+        Allows the approximation of kriging weights based on the OLS algorithm. We don't recommend set it to ``True``
+        if you don't know what are you doing. This parameter can be useful when you have clusters in your dataset,
+        that can lead to singular or near-singular matrix creation.
+
+    Returns
+    -------
+    : numpy array
+        ``[predicted value, variance error, longitude (x), latitude (y)]``
+
+    Raises
+    ------
+    RunetimeError
+        Singularity matrix in a Kriging system.
+    """
+
+    k, predicted, dataset = get_predictions(theoretical_model,
+                                            known_locations,
+                                            unknown_location,
+                                            neighbors_range,
+                                            no_neighbors,
+                                            use_all_neighbors_in_range)
+
+    k = sem_to_cov(k, sill)
+    predicted = sem_to_cov(predicted, sill)
+
+    k_ones = np.ones(1)[0]
+    k = np.r_[k, k_ones]
+
+    p_ones = np.ones((predicted.shape[0], 1))
+    predicted_with_ones_col = np.c_[predicted, p_ones]
+    p_ones_row = np.ones((1, predicted_with_ones_col.shape[1]))
+    p_ones_row[0][-1] = 0.
+    weights = np.r_[predicted_with_ones_col, p_ones_row]
+
+    try:
+        output_weights = solve_weights(weights, k, allow_approximate_solutions)
+    except np.linalg.LinAlgError as _:
+        msg = 'Singular matrix in Kriging system detected, check if you have duplicated coordinates ' \
+              'in the ``known_locations`` variable.'
+        raise RuntimeError(msg)
+
+    zhat = dataset[:, -2].dot(output_weights[:-1])
+
+    sigma = sill - np.matmul(output_weights.T, k)
 
     if sigma < 0:
         return [zhat, np.nan, unknown_location[0], unknown_location[1]]

--- a/pyinterpolate/processing/transform/transform.py
+++ b/pyinterpolate/processing/transform/transform.py
@@ -201,6 +201,27 @@ def point_support_to_dict(point_support: PointSupport) -> Dict:
     return d
 
 
+def sem_to_cov(semivariances, sill) -> np.ndarray:
+    """
+    Function transforms semivariances into a covariances.
+
+    Parameters
+    ----------
+    semivariances : Iterable
+
+    sill : float
+
+    Returns
+    -------
+    covariances : numpy array
+    """
+
+    if isinstance(semivariances, np.ndarray):
+        return sill - semivariances
+
+    return sill - np.asarray(semivariances)
+
+
 def transform_ps_to_dict(ps: Union[Dict, np.ndarray, gpd.GeoDataFrame, pd.DataFrame, PointSupport]) -> Dict:
     """
 

--- a/tests/debug_sandbox/kriging_from_cov.py
+++ b/tests/debug_sandbox/kriging_from_cov.py
@@ -1,0 +1,158 @@
+# Imports
+from typing import List, Tuple, Union
+import numpy as np
+from pyinterpolate import read_txt
+from pyinterpolate import ordinary_kriging  # kriging models
+from pyinterpolate.kriging.utils.process import get_predictions, solve_weights
+from pyinterpolate.variogram.empirical.experimental_variogram import ExperimentalVariogram
+from pyinterpolate import TheoreticalVariogram
+
+# Read data
+dem = read_txt('../samples/point_data/txt/pl_dem_epsg2180.txt')
+
+
+def create_model_validation_sets(dataset: np.array, frac=0.1):
+    indexes_of_training_set = np.random.choice(range(len(dataset) - 1), int(frac * len(dataset)), replace=False)
+    training_set = dataset[indexes_of_training_set]
+    validation_set = np.delete(dataset, indexes_of_training_set, 0)
+    return training_set, validation_set
+
+
+known_points, unknown_points = create_model_validation_sets(dem)
+
+
+def sem_to_cov(semivariances, sill) -> np.ndarray:
+    """
+    Function transforms semivariances into a covariances.
+
+    Parameters
+    ----------
+    semivariances : Iterable
+
+    sill : float
+
+    Returns
+    -------
+    covariances : numpy array
+
+    Notes
+    -----
+
+    sem = sill - cov
+    cov = sill - sem
+    """
+
+    if isinstance(semivariances, np.ndarray):
+        return sill - semivariances
+
+    return sill - np.asarray(semivariances)
+
+
+def ordinary_kriging2(
+        theoretical_model: TheoreticalVariogram,
+        known_locations: np.ndarray,
+        unknown_location: Union[List, Tuple, np.ndarray],
+        sill,
+        neighbors_range=None,
+        no_neighbors=4,
+        use_all_neighbors_in_range=False,
+        allow_approximate_solutions=False
+) -> List:
+    """
+    Function predicts value at unknown location with Ordinary Kriging technique.
+
+    Parameters
+    ----------
+    theoretical_model : TheoreticalVariogram
+        A trained theoretical variogram model.
+
+    known_locations : numpy array
+        The known locations.
+
+    unknown_location : Union[List, Tuple, numpy array]
+        Point where you want to estimate value ``(x, y) <-> (lon, lat)``.
+
+    neighbors_range : float, default=None
+        The maximum distance where we search for neighbors. If ``None`` is given then range is selected from
+        the ``theoretical_model`` ``rang`` attribute.
+
+    no_neighbors : int, default = 4
+        The number of the **n-closest neighbors** used for interpolation.
+
+    use_all_neighbors_in_range : bool, default = False
+        ``True``: if the real number of neighbors within the ``neighbors_range`` is greater than the
+        ``number_of_neighbors`` parameter then take all of them anyway.
+
+    allow_approximate_solutions : bool, default=False
+        Allows the approximation of kriging weights based on the OLS algorithm. We don't recommend set it to ``True``
+        if you don't know what are you doing. This parameter can be useful when you have clusters in your dataset,
+        that can lead to singular or near-singular matrix creation.
+
+    Returns
+    -------
+    : numpy array
+        ``[predicted value, variance error, longitude (x), latitude (y)]``
+
+    Raises
+    ------
+    RunetimeError
+        Singularity matrix in a Kriging system.
+    """
+
+    k, predicted, dataset = get_predictions(theoretical_model,
+                                            known_locations,
+                                            unknown_location,
+                                            neighbors_range,
+                                            no_neighbors,
+                                            use_all_neighbors_in_range)
+
+    k = sem_to_cov(k, sill)
+    predicted = sem_to_cov(predicted, sill)
+
+    k_ones = np.ones(1)[0]
+    k = np.r_[k, k_ones]
+
+    p_ones = np.ones((predicted.shape[0], 1))
+    predicted_with_ones_col = np.c_[predicted, p_ones]
+    p_ones_row = np.ones((1, predicted_with_ones_col.shape[1]))
+    p_ones_row[0][-1] = 0.
+    weights = np.r_[predicted_with_ones_col, p_ones_row]
+
+    try:
+        output_weights = solve_weights(weights, k, allow_approximate_solutions)
+    except np.linalg.LinAlgError as _:
+        msg = 'Singular matrix in Kriging system detected, check if you have duplicated coordinates ' \
+              'in the ``known_locations`` variable.'
+        raise RuntimeError(msg)
+
+    zhat = dataset[:, -2].dot(output_weights[:-1])
+
+    sigma = sill - np.matmul(output_weights.T, k)
+
+    if sigma < 0:
+        return [zhat, np.nan, unknown_location[0], unknown_location[1]]
+
+    return [zhat, sigma, unknown_location[0], unknown_location[1]]
+
+
+if __name__ == '__main__':
+
+    exp_var = ExperimentalVariogram(input_array=known_points, step_size=500, max_range=20000)
+    theo_var = TheoreticalVariogram()
+    theo_var.autofit(exp_var, model_types='spherical')
+    # theo_var.plot()
+
+    for _unknown_pt in unknown_points:
+        predicted_sem = ordinary_kriging(
+            theoretical_model=theo_var,
+            known_locations=known_points,
+            unknown_location=_unknown_pt[:-1]
+        )
+        predicted_cov = ordinary_kriging2(
+            theoretical_model=theo_var,
+            known_locations=known_points,
+            unknown_location=_unknown_pt[:-1],
+            sill=exp_var.variance
+        )
+
+        assert np.allclose(predicted_cov, predicted_sem, rtol=10, equal_nan=True)

--- a/tests/test_kriging/test_atp_pk.py
+++ b/tests/test_kriging/test_atp_pk.py
@@ -133,10 +133,10 @@ class TestATAPK(unittest.TestCase):
                                     number_of_neighbors=4,
                                     raise_when_negative_error=False)
 
-        expected_output = np.array([
+        expected_output = [
             [(2.8, 0.9), 133.33, 0.],
             [(3.2, 1.1), 266.67, 0.]
-        ])
+        ]
 
         self.assertEqual(pk_model[0][0], expected_output[0][0])
         self.assertAlmostEqual(pk_model[0][1], expected_output[0][1], places=2)


### PR DESCRIPTION
# Ordinary Kriging from Covariance

## Package version (main branch)
version: **0.3.5**

## Description
Ordinary Kriging from covariance terms instead of semivariance.

## Problem
It is an enhancement.

## Solution
n/a

### Affected modules

- kriging
- processing

### Unit tests

- `tests/test_kriging/test_ordinary_kriging.py`

### Package check

- [x] All tests passed
- [-] Documentation updated
- [-] All tutorials are working properly

### (Optional) Additional info
Is feature related to literature? Does change require new dependencies? Any other information...


