### PR TITLE
Updated tests for calculate_average_semivariance function

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -18,7 +18,9 @@ Changes by date
 * (enhancement) `transform_ps_to_dict()` function takes custom parameters for lon, lat, value and index,
 * (test) `check_limits()` function tests,
 * (test) plotting function of the `VariogramCloud()` class is tested and slightly changed to return `True` if everything has worked fine,
-*
+* (tutorials) new tutorial about `ExperimentalVariogram` and `VariogramCloud` classes,
+* (test) new tests for `calculate_average_semivariance()` function from `block` module,
+* 
 
 2023-01-16
 ----------

--- a/pyinterpolate/variogram/regularization/block/avg_inblock_semivariances.py
+++ b/pyinterpolate/variogram/regularization/block/avg_inblock_semivariances.py
@@ -104,7 +104,6 @@ def calculate_average_semivariance(block_to_block_distances: Dict,
                 partial_neighbors = [x for x in block_neighbors if x != block_name]
                 n_len = len(partial_neighbors)
                 if n_len > 0:
-                    # TODO: check if it is valid if there are no neighbors
                     n_semivariances = [inblock_semivariances[bid] for bid in partial_neighbors]
                     average_semivariance.extend(n_semivariances)
                     number_of_blocks_per_lag.append(no_of_areas)

--- a/tests/test_variogram/regularize/test_avg_inblock_semivariance.py
+++ b/tests/test_variogram/regularize/test_avg_inblock_semivariance.py
@@ -65,3 +65,30 @@ class TestCalculateAverageSemivariance(unittest.TestCase):
                                                           MAX_RANGE)
 
         self.assertIsInstance(avg_semivariance, np.ndarray)
+
+    def test_average_semivariance_no_neighbors(self):
+
+        distances_between_blocks = {
+            'a': [0, 2, 99],
+            'b': [2, 0, 300],
+            'c': [99, 300, 0]
+        }
+
+        inblock_semivariances = {'a': 10, 'b': 20, 'c': 900}
+
+        step_size = 1
+        max_range = 3
+
+        # Avg semi
+        avg_semivariance = calculate_average_semivariance(distances_between_blocks,
+                                                          inblock_semivariances,
+                                                          step_size,
+                                                          max_range)
+
+        arrays_equal = np.array_equal(avg_semivariance,
+                                      np.array([
+                                          [1, 0, 0],
+                                          [2, 7.5, 1]
+                                      ]))
+
+        self.assertTrue(arrays_equal)


### PR DESCRIPTION
# Updated tests for calculate average semivariance function

## Package version (main branch)
version: **0.3.6**

## Description
Test what happens if block without neighbors is passed.

## Problem
The output was undefined, block without neighbors shouldn't affect function output.

## Solution
Write unit test.

### Affected modules

- `variogram`

### Unit tests

- `test_average_semivariance_no_neighbors`

### Package check

- [x] All tests passed
- [-] Documentation updated
- [-] All tutorials are working properly

### (Optional) Additional info
Is feature related to literature? Does change require new dependencies? Any other information...


