### PR TITLE
refactor index

### DIFF
--- a/src/pyinterpolate/distance/block.py
+++ b/src/pyinterpolate/distance/block.py
@@ -293,8 +293,8 @@ def calc_block_to_block_distance(
 
 
 def select_neighbors_in_range(data: pd.DataFrame,
-                              current_lag: float,
-                              previous_lag: float):
+                             current_lag: float,
+                             previous_lag: float):
     """
     Function selects the neighbors of each block within a range given by
     previous and current lags.
@@ -313,16 +313,15 @@ def select_neighbors_in_range(data: pd.DataFrame,
     Returns
     -------
     neighbors : Dict
-        block id: [list of neighbors within a range
+        block index: [list of neighbor indexes within a range
         given by previous and current lags]
     """
 
-    cols = list(data.columns)
-    neighbors = data.reset_index(names='block_i')
-    neighbors = neighbors.melt(id_vars='block_i', value_vars=cols)
+    neighbors = data.reset_index()
+    neighbors = neighbors.melt(id_vars=neighbors.columns[0], value_vars=neighbors.columns[1:])
 
     neighbors = neighbors[
-        (neighbors > previous_lag) & (neighbors <= current_lag)
+        (neighbors['value'] > previous_lag) & (neighbors['value'] <= current_lag)
     ]
     dneighbors = neighbors.dropna()
 
@@ -331,7 +330,7 @@ def select_neighbors_in_range(data: pd.DataFrame,
     else:
         pneighbors = dneighbors.drop(columns='value')
         other_neighbors_col = pneighbors.columns[-1]
-        pneighbors = pneighbors.groupby('block_i')[
+        pneighbors = pneighbors.groupby(pneighbors.columns[0])[
             other_neighbors_col
         ].apply(list)
 


### PR DESCRIPTION
# <Feature Title>

## Package version (main branch)
version: 1.0

## Description
While deconvoluting a variogram, I got an error in the within blocks variance creating. I think this was because I was using a string as an index for the blocks. The error was caused by the function that selects the neighbouring blocks to calculate the block semivariogram. I updated the reindexing in `distance.blocks.select_neighbours_in_range`  and the conditional comparing of the distance and the lag. The comparison was done with `neighbors` and `lags` , it now compares the values explicitly.

## Problem
Users were restricted in indexing their blocks

## Solution
It is now more flexible, all indices should work 

### Affected modules
- `src/pyinterpolate/distance/block.py`

### Unit tests

- list of the new unit tests for presented feature

### Package check

- [x] All tests passed
- [x] Documentation updated
- [x] All tutorials are working properly

### (Optional) Additional info
Is feature related to literature? Does change require new dependencies? Any other information...


