### PR TITLE
fix repr of ExperimentalVariogram if custom_weights are None

### DIFF
--- a/src/pyinterpolate/semivariogram/experimental/classes/experimental_variogram.py
+++ b/src/pyinterpolate/semivariogram/experimental/classes/experimental_variogram.py
@@ -337,6 +337,11 @@ class ExperimentalVariogram:
 
         cname = 'ExperimentalVariogram'
 
+        # NoneType has no tolist()
+        custom_weights = (
+            self.custom_weights.tolist() if self.custom_weights is not None else "None"
+        )
+
         input_params = (f'ds={self.ds.tolist()},'
                         f'step_size={self.step_size},'
                         f'max_range={self.max_range},'
@@ -344,7 +349,7 @@ class ExperimentalVariogram:
                         f'tolerance={self.tolerance},'
                         f'dir_neighbors_selection_method={self.method},'
                         f'custom_bins={self.lags.tolist()},'
-                        f'custom_weights={self.custom_weights.tolist()},'
+                        f'custom_weights={custom_weights},'
                         f'is_semivariance={self.__c_sem},'
                         f'is_covariance={self.__c_cov}')
 


### PR DESCRIPTION
When there are no custom_weights in ExperimentalVariogram, `__repr__` fails with the following.

```py
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
File ~/dev/sds/.pixi/envs/default/lib/python3.12/site-packages/IPython/core/formatters.py:770, in PlainTextFormatter.__call__(self, obj)
    763 stream = StringIO()
    764 printer = pretty.RepresentationPrinter(stream, self.verbose,
    765     self.max_width, self.newline,
    766     max_seq_length=self.max_seq_length,
    767     singleton_pprinters=self.singleton_printers,
    768     type_pprinters=self.type_printers,
    769     deferred_pprinters=self.deferred_printers)
--> [770](https://file+.vscode-resource.vscode-cdn.net/Users/martin/dev/sds/~/dev/sds/.pixi/envs/default/lib/python3.12/site-packages/IPython/core/formatters.py:770) printer.pretty(obj)
    771 printer.flush()
    772 return stream.getvalue()

File ~/dev/sds/.pixi/envs/default/lib/python3.12/site-packages/IPython/lib/pretty.py:411, in RepresentationPrinter.pretty(self, obj)
    400                         return meth(obj, self, cycle)
    401                 if (
    402                     cls is not object
    403                     # check if cls defines __repr__
   (...)    409                     and callable(_safe_getattr(cls, "__repr__", None))
    410                 ):
--> [411](https://file+.vscode-resource.vscode-cdn.net/Users/martin/dev/sds/~/dev/sds/.pixi/envs/default/lib/python3.12/site-packages/IPython/lib/pretty.py:411)                     return _repr_pprint(obj, self, cycle)
    413     return _default_pprint(obj, self, cycle)
    414 finally:

File ~/dev/sds/.pixi/envs/default/lib/python3.12/site-packages/IPython/lib/pretty.py:786, in _repr_pprint(obj, p, cycle)
    784 """A pprint that just redirects to the normal repr function."""
    785 # Find newlines and replace them with p.break_()
--> [786](https://file+.vscode-resource.vscode-cdn.net/Users/martin/dev/sds/~/dev/sds/.pixi/envs/default/lib/python3.12/site-packages/IPython/lib/pretty.py:786) output = repr(obj)
    787 lines = output.splitlines()
    788 with p.group():

File ~/dev/sds/.pixi/envs/default/lib/python3.12/site-packages/pyinterpolate/semivariogram/experimental/classes/experimental_variogram.py:347, in ExperimentalVariogram.__repr__(self)
    325 """
    326 ds: np.ndarray,
    327 step_size: float = None,
   (...)    335 is_covariance=True
    336 """
    338 cname = 'ExperimentalVariogram'
    340 input_params = (f'ds={self.ds.tolist()},'
    341                 f'step_size={self.step_size},'
    342                 f'max_range={self.max_range},'
    343                 f'direction={self.direction},'
    344                 f'tolerance={self.tolerance},'
    345                 f'dir_neighbors_selection_method={self.method},'
    346                 f'custom_bins={self.lags.tolist()},'
--> [347](https://file+.vscode-resource.vscode-cdn.net/Users/martin/dev/sds/~/dev/sds/.pixi/envs/default/lib/python3.12/site-packages/pyinterpolate/semivariogram/experimental/classes/experimental_variogram.py:347)                 f'custom_weights={self.custom_weights.tolist()},'
    348                 f'is_semivariance={self.__c_sem},'
    349                 f'is_covariance={self.__c_cov}')
    351 repr_val = cname + '(' + input_params + ')'
    352 return repr_val

AttributeError: 'NoneType' object has no attribute 'tolist'
```

This catches the issue and returns plain string `"None"` instead.

I have not found tests for repr so have not added this. Can be reproduced by following the code in https://martinfleischmann.net/sds/interpolation/hands_on.html.